### PR TITLE
Display an appropriate error message if location could not be retrieved.

### DIFF
--- a/app/src/main/java/com/i906/mpt/location/LocationRepository.java
+++ b/app/src/main/java/com/i906/mpt/location/LocationRepository.java
@@ -7,6 +7,7 @@ import com.google.android.gms.location.LocationRequest;
 import com.i906.mpt.prefs.HiddenPreferences;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -87,5 +88,9 @@ public class LocationRepository {
     public static float getDistance(Location a, Location b) {
         if (a == null || b == null) return Float.MAX_VALUE;
         return a.distanceTo(b);
+    }
+
+    public static boolean isThrowableLocationSettingsRelated(Throwable throwable) {
+        return throwable instanceof SecurityException || throwable instanceof TimeoutException;
     }
 }

--- a/app/src/main/java/com/i906/mpt/mosque/ui/MosqueFragment.java
+++ b/app/src/main/java/com/i906/mpt/mosque/ui/MosqueFragment.java
@@ -22,6 +22,7 @@ import com.i906.mpt.R;
 import com.i906.mpt.api.foursquare.Mosque;
 import com.i906.mpt.common.BaseFragment;
 import com.i906.mpt.common.DividerItemDecoration;
+import com.i906.mpt.location.LocationRepository;
 
 import java.util.List;
 
@@ -176,5 +177,13 @@ public class MosqueFragment extends BaseFragment implements MosqueView, MosqueAd
     public void onDetach() {
         super.onDetach();
         mPresenter.setView(null);
+    }
+
+    @Override
+    protected int getErrorMessage(Throwable e, int defaultResId) {
+        if (LocationRepository.isThrowableLocationSettingsRelated(e)) {
+            return R.string.error_no_location;
+        }
+        return super.getErrorMessage(e, defaultResId);
     }
 }

--- a/app/src/main/java/com/i906/mpt/prayer/ui/PrayerFragment.java
+++ b/app/src/main/java/com/i906/mpt/prayer/ui/PrayerFragment.java
@@ -18,6 +18,7 @@ import android.widget.ViewFlipper;
 
 import com.i906.mpt.R;
 import com.i906.mpt.common.BaseFragment;
+import com.i906.mpt.location.LocationRepository;
 import com.i906.mpt.prayer.PrayerContext;
 import com.i906.mpt.settings.SettingsActivity;
 
@@ -181,5 +182,13 @@ public class PrayerFragment extends BaseFragment implements PrayerView {
     public void onDetach() {
         super.onDetach();
         mPresenter.setView(null);
+    }
+
+    @Override
+    protected int getErrorMessage(Throwable e, int defaultResId) {
+        if (LocationRepository.isThrowableLocationSettingsRelated(e)) {
+            return R.string.error_no_location;
+        }
+        return super.getErrorMessage(e, defaultResId);
     }
 }


### PR DESCRIPTION
I override getErrorMessage() on the affected fragments.

Not sure whether I should change it on the base getErrorMessage().
